### PR TITLE
Various typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ Publication as an Editors' Draft does not imply endorsement by the W3C Membershi
 
 <section>
       <h3>WCAG 2.0 and Mobile Content/Applications</h3>
-      <p><em>"Mobile"</em> is a generic term for a broad range of wireless   devices and applications that are easy to carry and use in a wide   variety of settings, including outdoors. Mobile devices range from small   handheld devices (e.g. feature phones, smartphones) to somewhat larger   tablet devices. The term also applies to <em>"wearables"</em> such as   "smart"-glasses, "smart"-watches and fitness bands,, and is relevant to   other small computing devices such as those embedded into car   dashboards, airplane seatbacks, and household appliances. </p>
+      <p><em>"Mobile"</em> is a generic term for a broad range of wireless   devices and applications that are easy to carry and use in a wide   variety of settings, including outdoors. Mobile devices range from small   handheld devices (e.g. feature phones, smartphones) to somewhat larger   tablet devices. The term also applies to <em>"wearables"</em> such as   "smart"-glasses, "smart"-watches and fitness bands, and is relevant to   other small computing devices such as those embedded into car   dashboards, airplane seatbacks, and household appliances. </p>
       <p>While mobile is viewed by some as separate from <em>"desktop/laptop"</em>,   and thus perhaps requiring new and different accessibility guidance, in   reality there is no absolute divide between the categories. For   example: </p>
       <ul>
         <li>many desktop/laptop devices now include touchscreen gesture control, </li>
@@ -110,17 +110,17 @@ including assistive technologies.</p>
   <section>
     <h4>Small Screen Size</h4>
     <p>Small screen size is one of the most common characteristics of mobile devices. While the exceptional resolution of these screens theoretically enables large amounts of information to be rendered, the small size of the screen places practical limits on how much information people can actually view at one time, especially when magnification is used by people with low vision. </p>
-    <p>Some best practices for helping users to make the most of small screens include </p>
+    <p>Some best practices for helping users to make the most of small screens include: </p>
     <ul>
-    <li>Minimizing the amount of information that is put on each page compared to desktop/laptop versions by providing a dedicated mobile version or a responsive design: 
+    <li>minimizing the amount of information that is put on each page compared to desktop/laptop versions by providing a dedicated mobile version or a responsive design: 
     	<ul>
         	<li>a dedicated mobile version contains content tailored for mobile use. For example, the content may contain fewer content modules, fewer images, or focus on important mobile usage scenarios. </li>
-        	<li>a responsive design contains content that stays the same, but CSS   stylesheets are used to render it differently depending on the viewport   width. For example, on narrow screens the navigation menus may be hidden   until the user taps a menu button. </li>
+        	<li>a responsive design contains content that stays the same, but CSS   is used to render it differently depending on the viewport   width. For example, on narrow screens the navigation menus may be hidden   until the user taps a menu button. </li>
         </ul>
     </li>
-    <li>Providing a reasonable default size for content and touch controls (see "B.2 Touch Target Size and Spacing") to minimize the need to zoom in and out for users with low vision. </li>
-    <li> Adapting the length of link text to the viewport width. </li>
-    <li> Positioning form fields below, rather than beside, their labels (in portrait layout) </li>
+    <li>providing a reasonable default size for content and touch controls (see "B.2 Touch Target Size and Spacing") to minimize the need to zoom in and out for users with low vision. </li>
+    <li>adapting the length of link text to the viewport width. </li>
+    <li>positioning form fields below, rather than beside, their labels (in portrait layout) </li>
     </ul>
    </section>
    <section>   
@@ -225,7 +225,7 @@ including assistive technologies.</p>
   </section>
   <section>
   <h3>Device Manipulation Gestures</h3>
-  <p>In addition to touchscreen gestures, many mobile operating systems   provide developers with control options that are triggered by physically   manipulating the device(e.g. shaking or tilting). While device   manipulation gestures can help developers create innovative user   interfaces, they can also be a challenge for people who have difficulty   holding or are unable to hold a mobile device. </p>
+  <p>In addition to touchscreen gestures, many mobile operating systems   provide developers with control options that are triggered by physically   manipulating the device (e.g. shaking or tilting). While device   manipulation gestures can help developers create innovative user   interfaces, they can also be a challenge for people who have difficulty   holding or are unable to hold a mobile device. </p>
   <p>Some (but not all) mobile operating systems provide work-around   features that let the user simulate device shakes, tilts, etc. from an   onscreen menu. </p>
   <p>Therefore, even when device manipulation gestures are provided,   developers should still provide touch and keyboard operable alternative   control options. </p>
   <div class="successcriteria">


### PR DESCRIPTION
- Removed duplicate comma in "such as "smart"-glasses, "smart"-watches and fitness bands,, and…”
- Updated formatting of list for consistency in "Some best practices for helping users to make the most of small screens include"
- "CSS stylesheets" --> CSS since CSS = Cascading Stylesheets
- Added space in between "device(" for "In addition to touchscreen gestures, many mobile operating systems provide developers with control options that are triggered by physically manipulating the device(e.g. shaking or tilting)."
